### PR TITLE
HOTFIX: Change deploy dir from build to dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d build",
+    "deploy": "gh-pages -d dist",
     "lint": "eslint --config eslint.config.js \"src/**/*.{js,jsx}\""
   },
   "devDependencies": {


### PR DESCRIPTION
Change deploy directory from `build` to `dist` again.